### PR TITLE
Fix async null pointer and some warnings during test

### DIFF
--- a/src/main/scala/io/vertx/ext/asyncsql/impl/BaseSQLClient.scala
+++ b/src/main/scala/io/vertx/ext/asyncsql/impl/BaseSQLClient.scala
@@ -54,8 +54,8 @@ trait BaseSQLClient {
   def close(stopped: Handler[AsyncResult[Void]]): Unit = {
     logger.info(s"Stopping AsyncSqlClient:${getClass.getName}")
     pool.close() onComplete {
-      case Success(p) => stopped.handle(VFuture.succeededFuture())
-      case Failure(ex) => stopped.handle(VFuture.failedFuture(ex))
+      case Success(p) => Option(stopped).foreach(_.handle(VFuture.succeededFuture()))
+      case Failure(ex) => Option(stopped).foreach(_.handle(VFuture.failedFuture(ex)))
     }
   }
 

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
@@ -2,16 +2,15 @@ package io.vertx.ext.asyncsql;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
 
 /**
  * @author <a href="http://www.campudus.com">Joern Bernhardt</a>.
  */
 public class PostgreSQLTest extends VertxTestBase {
-  private static final Logger log = LoggerFactory.getLogger(VertxTestBase.class);
 
   AsyncSQLClient asyncSqlClient;
 
@@ -25,17 +24,35 @@ public class PostgreSQLTest extends VertxTestBase {
     asyncSqlClient = PostgreSQLClient.createNonShared(vertx, config);
   }
 
+  @Override
+  public void tearDown() throws Exception {
+    CountDownLatch latch;
+    if (this.asyncSqlClient != null) {
+      latch = new CountDownLatch(1);
+      this.asyncSqlClient.close((ar) -> {
+        latch.countDown();
+      });
+      this.awaitLatch(latch);
+    }
+
+    super.tearDown();
+  }
+
   @Test
   public void someTest() throws Exception {
-    log.info("before getConnection");
     asyncSqlClient.getConnection(onSuccess(conn -> {
-      log.info("in getConnection");
       conn.query("SELECT 1 AS something", onSuccess(resultSet -> {
         assertNotNull(resultSet);
         assertNotNull(resultSet.getColumnNames());
         assertNotNull(resultSet.getResults());
         assertEquals(new JsonArray().add(1), resultSet.getResults().get(0));
-        testComplete();
+        conn.close((ar) -> {
+          if (ar.succeeded()) {
+            testComplete();
+          } else {
+            fail("should be able to close the asyncSqlClient");
+          }
+        });
       }));
     }));
 

--- a/src/test/scala/io/vertx/ext/asyncsql/DirectTestBase.scala
+++ b/src/test/scala/io/vertx/ext/asyncsql/DirectTestBase.scala
@@ -15,7 +15,6 @@ abstract class DirectTestBase extends SQLTestBase with ConfigProvider {
 
   override def setUp(): Unit = {
     super.setUp()
-    val latch: CountDownLatch = new CountDownLatch(1)
   }
 
   override def tearDown(): Unit = {


### PR DESCRIPTION
- Make sure that the client is closed properly before starting another test
- Fix null pointer when not adding a AsyncResultHandler in close()

Signed-off-by: Joern Bernhardt <jb@campudus.com>