### PR TITLE
Fix database warning about already started transaction

### DIFF
--- a/src/test/scala/io/vertx/ext/asyncsql/SQLTestBase.scala
+++ b/src/test/scala/io/vertx/ext/asyncsql/SQLTestBase.scala
@@ -295,9 +295,8 @@ abstract class SQLTestBase extends VertxTestBase with TestData {
       conn <- f
       _ <- arhToFuture(conn.close _)
     } yield {
-        log.info("closed connection -> done")
-        testComplete()
-      }) recover {
+      testComplete()
+    }) recover {
       case ex =>
         log.error("should not get this exception", ex)
         fail("got exception")


### PR DESCRIPTION
Should fix #16 . I have no idea how to test the database log of Postgres here, but I could see the warning go away after using the new test `makeTwoTransactionsAfterEachOther`.