### PR TITLE
Fix some comments (obsolete or incorrect)

### DIFF
--- a/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
@@ -55,8 +55,7 @@ public class MySQLClientTest extends SQLTestBase {
       // INFO: we ignore the result of this call because it is a mysql specific feature and not all versions support it
       // what is means is that we want the sql parser to be strict even if the engine e.g.: myisam does not implement
       // all constraints such as is the date Feb 31 a valid date. By specifying this we will tell for example that the
-      // previous date is invalid. For Postgres this is an uknown config so it will report an error, so we ignore it
-      // too.
+      // previous date is invalid.
       handler.handle(null);
     });
   }

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLClientTest.java
@@ -33,7 +33,7 @@ public class PostgreSQLClientTest extends SQLTestBase {
 
 
   /**
-   * @return the String form of the time returned for "2015-02-22T07:15:01.234Z".
+   * @return the String form of the time returned for "2015-02-22T07:15:01.234".
    */
   @Override
   public String getExpectedTime1() {
@@ -41,7 +41,7 @@ public class PostgreSQLClientTest extends SQLTestBase {
   }
 
   /**
-   * @return the String form of the time returned for "2014-06-27T17:50:02.468+02:00".
+   * @return the String form of the time returned for "2014-06-27T17:50:02.468".
    */
   @Override
   public String getExpectedTime2() {


### PR DESCRIPTION
As we split PostgreSQL and MySQL tests, one comment about PostgreSQL was obsolete.
The other one didn't tell the truth about what is returned by the function.