### PR TITLE
Add configuration options for charset and timeout

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -15,7 +15,7 @@ application.
 
 To use this client, you need to add the following jar to your `CLASSPATH`:
 
-* vertx-mysql-postgresql-client 3.2.1 (the client)
+* vertx-mysql-postgresql-client 3.3.0-SNAPSHOT (the client)
 * scala-library 2.11.4
 * the postgress-async-2.11 and mysdql-async-2.11 from https://github.com/mauricio/postgresql-async
 * joda time
@@ -33,7 +33,7 @@ If you are building a _Fat-jar_ using Maven or Gradle, just add the following de
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mysql-postgresql-client</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -41,7 +41,7 @@ If you are building a _Fat-jar_ using Maven or Gradle, just add the following de
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-mysql-postgresql-client:3.2.1'
+compile 'io.vertx:vertx-mysql-postgresql-client:3.3.0-SNAPSHOT'
 ----
 
 === In an application using a vert.x distributions
@@ -232,7 +232,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "maxPoolSize" : <maximum-number-of-open-connections>,
   "username" : <your-username>,
   "password" : <your-password>,
-  "database" : <name-of-your-database>
+  "database" : <name-of-your-database>,
+  "charset" : <name-of-the-character-set>,
+  "queryTimeout" : <timeout-in-milliseconds>
 }
 ----
 
@@ -242,3 +244,5 @@ Both the PostgreSql and MySql clients take the same configuration:
 `username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
 `password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
 `database`:: The name of the database you want to connect to. Defaults to `test`.
+`charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -15,7 +15,7 @@ application.
 
 To use this client, you need to add the following jar to your `CLASSPATH`:
 
-* vertx-mysql-postgresql-client 3.2.1 (the client)
+* vertx-mysql-postgresql-client 3.3.0-SNAPSHOT (the client)
 * scala-library 2.11.4
 * the postgress-async-2.11 and mysdql-async-2.11 from https://github.com/mauricio/postgresql-async
 * joda time
@@ -33,7 +33,7 @@ If you are building a _Fat-jar_ using Maven or Gradle, just add the following de
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mysql-postgresql-client</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -41,7 +41,7 @@ If you are building a _Fat-jar_ using Maven or Gradle, just add the following de
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-mysql-postgresql-client:3.2.1'
+compile 'io.vertx:vertx-mysql-postgresql-client:3.3.0-SNAPSHOT'
 ----
 
 === In an application using a vert.x distributions
@@ -194,7 +194,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "maxPoolSize" : <maximum-number-of-open-connections>,
   "username" : <your-username>,
   "password" : <your-password>,
-  "database" : <name-of-your-database>
+  "database" : <name-of-your-database>,
+  "charset" : <name-of-the-character-set>,
+  "queryTimeout" : <timeout-in-milliseconds>
 }
 ----
 
@@ -204,3 +206,5 @@ Both the PostgreSql and MySql clients take the same configuration:
 `username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
 `password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
 `database`:: The name of the database you want to connect to. Defaults to `test`.
+`charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -15,7 +15,7 @@ application.
 
 To use this client, you need to add the following jar to your `CLASSPATH`:
 
-* vertx-mysql-postgresql-client 3.2.1 (the client)
+* vertx-mysql-postgresql-client 3.3.0-SNAPSHOT (the client)
 * scala-library 2.11.4
 * the postgress-async-2.11 and mysdql-async-2.11 from https://github.com/mauricio/postgresql-async
 * joda time
@@ -33,7 +33,7 @@ If you are building a _Fat-jar_ using Maven or Gradle, just add the following de
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mysql-postgresql-client</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -41,7 +41,7 @@ If you are building a _Fat-jar_ using Maven or Gradle, just add the following de
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-mysql-postgresql-client:3.2.1'
+compile 'io.vertx:vertx-mysql-postgresql-client:3.3.0-SNAPSHOT'
 ----
 
 === In an application using a vert.x distributions
@@ -232,7 +232,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "maxPoolSize" : <maximum-number-of-open-connections>,
   "username" : <your-username>,
   "password" : <your-password>,
-  "database" : <name-of-your-database>
+  "database" : <name-of-your-database>,
+  "charset" : <name-of-the-character-set>,
+  "queryTimeout" : <timeout-in-milliseconds>
 }
 ----
 
@@ -242,3 +244,5 @@ Both the PostgreSql and MySql clients take the same configuration:
 `username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
 `password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
 `database`:: The name of the database you want to connect to. Defaults to `test`.
+`charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -15,7 +15,7 @@ application.
 
 To use this client, you need to add the following jar to your `CLASSPATH`:
 
-* vertx-mysql-postgresql-client 3.2.1 (the client)
+* vertx-mysql-postgresql-client 3.3.0-SNAPSHOT (the client)
 * scala-library 2.11.4
 * the postgress-async-2.11 and mysdql-async-2.11 from https://github.com/mauricio/postgresql-async
 * joda time
@@ -33,7 +33,7 @@ If you are building a _Fat-jar_ using Maven or Gradle, just add the following de
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mysql-postgresql-client</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -41,7 +41,7 @@ If you are building a _Fat-jar_ using Maven or Gradle, just add the following de
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-mysql-postgresql-client:3.2.1'
+compile 'io.vertx:vertx-mysql-postgresql-client:3.3.0-SNAPSHOT'
 ----
 
 === In an application using a vert.x distributions
@@ -232,7 +232,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "maxPoolSize" : <maximum-number-of-open-connections>,
   "username" : <your-username>,
   "password" : <your-password>,
-  "database" : <name-of-your-database>
+  "database" : <name-of-your-database>,
+  "charset" : <name-of-the-character-set>,
+  "queryTimeout" : <timeout-in-milliseconds>
 }
 ----
 
@@ -242,3 +244,5 @@ Both the PostgreSql and MySql clients take the same configuration:
 `username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
 `password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
 `database`:: The name of the database you want to connect to. Defaults to `test`.
+`charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).

--- a/src/main/generated/io/vertx/rxjava/ext/asyncsql/PostgreSQLClient.java
+++ b/src/main/generated/io/vertx/rxjava/ext/asyncsql/PostgreSQLClient.java
@@ -54,8 +54,7 @@ public class PostgreSQLClient extends AsyncSQLClient {
   }
 
   /**
-   * Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same
-   * pool name.
+   * Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same pool name.
    * @param vertx the Vert.x instance
    * @param config the configuration
    * @param poolName the pool name

--- a/src/main/groovy/io/vertx/groovy/ext/asyncsql/PostgreSQLClient.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/asyncsql/PostgreSQLClient.groovy
@@ -44,8 +44,7 @@ public class PostgreSQLClient extends AsyncSQLClient {
     return ret;
   }
   /**
-   * Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same
-   * pool name.
+   * Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same pool name.
    * @param vertx the Vert.x instance
    * @param config the configuration
    * @param poolName the pool name

--- a/src/main/java/io/vertx/ext/asyncsql/MySQLClient.java
+++ b/src/main/java/io/vertx/ext/asyncsql/MySQLClient.java
@@ -62,6 +62,21 @@ public interface MySQLClient extends AsyncSQLClient {
    */
   String DEFAULT_PASSWORD = "password";
 
+  /**
+   * The default charset.
+   */
+  String DEFAULT_CHARSET = "UTF-8";
+
+  /**
+   * The default timeout for connect.
+   */
+  long DEFAULT_CONNECT_TIMEOUT = 10000L;
+
+  /**
+   * The default timeout for tests.
+   */
+  long DEFAULT_TEST_TIMEOUT = 10000L;
+
 
   /**
    * Create a MySQL client which maintains its own pool.

--- a/src/main/java/io/vertx/ext/asyncsql/PostgreSQLClient.java
+++ b/src/main/java/io/vertx/ext/asyncsql/PostgreSQLClient.java
@@ -62,12 +62,27 @@ public interface PostgreSQLClient extends AsyncSQLClient {
    */
   String DEFAULT_PASSWORD = "password";
 
+  /**
+   * The default charset.
+   */
+  String DEFAULT_CHARSET = "UTF-8";
+
+  /**
+   * The default timeout for connect.
+   */
+  long DEFAULT_CONNECT_TIMEOUT = 10000L;
+
+  /**
+   * The default timeout for tests.
+   */
+  long DEFAULT_TEST_TIMEOUT = 10000L;
+
 
   /**
    * Create a PostgreSQL client which maintains its own pool.
    *
-   * @param vertx   the Vert.x instance
-   * @param config  the configuration
+   * @param vertx  the Vert.x instance
+   * @param config the configuration
    * @return the client
    */
   static AsyncSQLClient createNonShared(Vertx vertx, JsonObject config) {
@@ -75,15 +90,14 @@ public interface PostgreSQLClient extends AsyncSQLClient {
   }
 
   /**
-   * Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same
-   * pool name.
+   * Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same pool name.
    *
    * @param vertx    the Vert.x instance
    * @param config   the configuration
    * @param poolName the pool name
    * @return the client
    */
-  static AsyncSQLClient createShared(Vertx vertx,JsonObject config, String poolName) {
+  static AsyncSQLClient createShared(Vertx vertx, JsonObject config, String poolName) {
     return ClientHelper.getOrCreate(vertx, config, poolName, false);
   }
 
@@ -91,8 +105,8 @@ public interface PostgreSQLClient extends AsyncSQLClient {
   /**
    * Like {@link #createShared(io.vertx.core.Vertx, JsonObject, String)} but with the default pool name
    *
-   * @param vertx   the Vert.x instance
-   * @param config  the configuration
+   * @param vertx  the Vert.x instance
+   * @param config the configuration
    * @return the client
    */
   static AsyncSQLClient createShared(Vertx vertx, JsonObject config) {

--- a/src/main/java/io/vertx/ext/asyncsql/impl/BaseSQLClient.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/BaseSQLClient.java
@@ -33,6 +33,7 @@ import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.Duration;
 
+import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -57,6 +58,7 @@ public abstract class BaseSQLClient {
   }
 
   protected abstract AsyncConnectionPool pool();
+
   protected abstract SQLConnection createFromPool(Connection conn, AsyncConnectionPool pool, ExecutionContext ec);
 
   public void getConnection(Handler<AsyncResult<SQLConnection>> handler) {
@@ -91,17 +93,37 @@ public abstract class BaseSQLClient {
     close(null);
   }
 
-  protected Configuration getConfiguration(String defaultHost, int defaultPort, String defaultDatabase, String defaultUser, String defaultPassword, JsonObject config) {
+  protected Configuration getConfiguration(
+      String defaultHost,
+      int defaultPort,
+      String defaultDatabase,
+      String defaultUser,
+      String defaultPassword,
+      String defaultCharset,
+      long defaultConnectTimeout,
+      long defaultTestTimeout,
+      JsonObject config) {
+
     String host = config.getString("host", defaultHost);
     int port = config.getInteger("port", defaultPort);
     String username = config.getString("username", defaultUser);
     String password = config.getString("password", defaultPassword);
     String database = config.getString("database", defaultDatabase);
+    Charset charset = Charset.forName(config.getString("charset", defaultCharset));
+    long connectTimeout = config.getLong("connectTimeout", defaultConnectTimeout);
+    long testTimeout = config.getLong("testTimeout", defaultTestTimeout);
+    Long queryTimeout = config.getLong("queryTimeout");
+    Option<Duration> queryTimeoutOption = (queryTimeout == null) ?
+        Option.empty() : Option.apply(Duration.apply(queryTimeout, TimeUnit.MILLISECONDS));
 
     log.info("Creating configuration for " + host + ":" + port);
     return new Configuration(username, host, port, Option.apply(password), Option.apply(database),
-        CharsetUtil.UTF_8, 16777216, PooledByteBufAllocator.DEFAULT,
-        Duration.apply(5, TimeUnit.SECONDS), Duration.apply(5, TimeUnit.SECONDS), Option.empty());
+        charset,
+        16777216,
+        PooledByteBufAllocator.DEFAULT,
+        Duration.apply(connectTimeout, TimeUnit.MILLISECONDS),
+        Duration.apply(testTimeout, TimeUnit.MILLISECONDS),
+        queryTimeoutOption);
   }
 
 

--- a/src/main/java/io/vertx/ext/asyncsql/impl/MYSQLClientImpl.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/MYSQLClientImpl.java
@@ -43,6 +43,9 @@ public class MYSQLClientImpl extends BaseSQLClient {
         MySQLClient.DEFAULT_DATABASE,
         MySQLClient.DEFAULT_USER,
         MySQLClient.DEFAULT_PASSWORD,
+        MySQLClient.DEFAULT_CHARSET,
+        MySQLClient.DEFAULT_CONNECT_TIMEOUT,
+        MySQLClient.DEFAULT_TEST_TIMEOUT,
         config));
   }
 

--- a/src/main/java/io/vertx/ext/asyncsql/impl/PostgreSQLClientImpl.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/PostgreSQLClientImpl.java
@@ -42,6 +42,9 @@ public class PostgreSQLClientImpl extends BaseSQLClient {
         PostgreSQLClient.DEFAULT_DATABASE,
         PostgreSQLClient.DEFAULT_USER,
         PostgreSQLClient.DEFAULT_PASSWORD,
+        PostgreSQLClient.DEFAULT_CHARSET,
+        PostgreSQLClient.DEFAULT_CONNECT_TIMEOUT,
+        PostgreSQLClient.DEFAULT_TEST_TIMEOUT,
         config));
   }
 

--- a/src/main/java/io/vertx/ext/asyncsql/package-info.java
+++ b/src/main/java/io/vertx/ext/asyncsql/package-info.java
@@ -183,7 +183,9 @@
  *   "maxPoolSize" : <maximum-number-of-open-connections>,
  *   "username" : <your-username>,
  *   "password" : <your-password>,
- *   "database" : <name-of-your-database>
+ *   "database" : <name-of-your-database>,
+ *   "charset" : <name-of-the-character-set>,
+ *   "queryTimeout" : <timeout-in-milliseconds>
  * }
  * ----
  *
@@ -193,6 +195,8 @@
  * `username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
  * `password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
  * `database`:: The name of the database you want to connect to. Defaults to `test`.
+ * `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
+ * `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
  */
 @Document(fileName = "index.adoc")
 @ModuleGen(name = "vertx-mysql-postgresql", groupPackage = "io.vertx") package io.vertx.ext.asyncsql;

--- a/src/main/resources/vertx-mysql-postgresql-js/postgre_sql_client.js
+++ b/src/main/resources/vertx-mysql-postgresql-js/postgre_sql_client.js
@@ -56,8 +56,7 @@ PostgreSQLClient.createNonShared = function(vertx, config) {
 };
 
 /**
- Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same
- pool name.
+ Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same pool name.
 
  @memberof module:vertx-mysql-postgresql-js/postgre_sql_client
  @param vertx {Vertx} the Vert.x instance 

--- a/src/main/resources/vertx-mysql-postgresql/postgre_sql_client.rb
+++ b/src/main/resources/vertx-mysql-postgresql/postgre_sql_client.rb
@@ -26,8 +26,7 @@ module VertxMysqlPostgresql
       end
       raise ArgumentError, "Invalid arguments when calling create_non_shared(vertx,config)"
     end
-    #  Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same
-    #  pool name.
+    #  Create a PostgreSQL client which shares its pool with any other MySQL clients created with the same pool name.
     # @param [::Vertx::Vertx] vertx the Vert.x instance
     # @param [Hash{String => Object}] config the configuration
     # @param [String] poolName the pool name

--- a/src/test/java/io/vertx/ext/asyncsql/AbstractTestBase.java
+++ b/src/test/java/io/vertx/ext/asyncsql/AbstractTestBase.java
@@ -1,0 +1,46 @@
+package io.vertx.ext.asyncsql;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Vertx;
+import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public abstract class AbstractTestBase {
+
+  protected AsyncSQLClient client;
+  protected static Vertx vertx;
+  protected SQLConnection conn;
+
+  @BeforeClass
+  public static void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @AfterClass
+  public static void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
+  }
+
+  @After
+  public void cleanup(TestContext context) {
+    if (conn != null) {
+      conn.close(context.asyncAssertSuccess());
+    }
+    if (client != null) {
+      client.close(context.asyncAssertSuccess());
+    }
+  }
+
+  protected void ensureSuccess(TestContext context, AsyncResult result) {
+    if (result.failed()) {
+      context.fail(result.cause());
+    }
+  }
+
+}

--- a/src/test/java/io/vertx/ext/asyncsql/ConfigurationTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/ConfigurationTest.java
@@ -1,0 +1,109 @@
+package io.vertx.ext.asyncsql;
+
+import com.github.mauricio.async.db.exceptions.ConnectionTimeoutedException;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+public abstract class ConfigurationTest extends AbstractTestBase {
+
+  protected abstract AsyncSQLClient createClient(Vertx vertx, JsonObject config);
+
+  protected abstract String sleepCommand(int seconds);
+
+  protected abstract String getEncodingStatement();
+
+  protected abstract String getEncodingValueFromResults(List<JsonArray> results);
+
+  @Test
+  public void testCharset(TestContext context) {
+    Async async = context.async();
+    showEncoding(context, "iso-8859-1", encoding1 -> {
+      showEncoding(context, "utf-8", encoding2 -> {
+        context.assertNotEquals(encoding1, encoding2);
+        async.complete();
+      });
+    });
+  }
+
+  private void showEncoding(TestContext context, String charSetString, Handler<String> encodingHandler) {
+
+    client = createClient(vertx,
+        new JsonObject()
+            .put("host", System.getProperty("db.host", "localhost"))
+            .put("charset", charSetString)
+    );
+
+    client.getConnection(sqlConnectionAsyncResult -> {
+      ensureSuccess(context, sqlConnectionAsyncResult);
+      conn = sqlConnectionAsyncResult.result();
+      conn.query(getEncodingStatement(), showEncodingAr -> {
+        ensureSuccess(context, showEncodingAr);
+        String encoding = getEncodingValueFromResults(showEncodingAr.result().getResults());
+        conn.close(connCloseAr -> {
+          ensureSuccess(context, connCloseAr);
+          conn = null;
+
+          client.close(clientCloseAr -> {
+            ensureSuccess(context, clientCloseAr);
+            client = null;
+
+            encodingHandler.handle(encoding);
+
+          });
+        });
+      });
+    });
+  }
+
+  @Ignore("Not implemented in driver yet, see https://github.com/mauricio/postgresql-async/issues/6")
+  @Test
+  public void testConnectionTimeout(TestContext context) {
+    Async async = context.async();
+    client = createClient(vertx,
+        new JsonObject()
+            .put("host", System.getProperty("db.host", "localhost"))
+            .put("connectTimeout", Long.parseLong(System.getProperty("db.connectTimeout", "1")))
+    );
+
+    client.getConnection(sqlConnectionAsyncResult -> {
+      if (sqlConnectionAsyncResult.failed()) {
+        context.assertTrue(sqlConnectionAsyncResult.cause() instanceof ConnectionTimeoutedException);
+        async.complete();
+      } else {
+        context.fail("Should fail due to a connection timeout exception");
+      }
+    });
+  }
+
+  @Test
+  public void testQueryTimeout(TestContext context) {
+    Async async = context.async();
+    client = createClient(vertx,
+        new JsonObject()
+            .put("host", System.getProperty("db.host", "localhost"))
+            .put("queryTimeout", Long.parseLong(System.getProperty("db.queryTimeout", "1")))
+    );
+
+    client.getConnection(sqlConnectionAsyncResult -> {
+      conn = sqlConnectionAsyncResult.result();
+      conn.query("SELECT " + sleepCommand(2), ar -> {
+        if (ar.failed()) {
+          context.assertTrue(ar.cause() instanceof TimeoutException);
+          async.complete();
+        } else {
+          context.fail("Should fail due to a connection timeout exception");
+        }
+      });
+    });
+  }
+
+}

--- a/src/test/java/io/vertx/ext/asyncsql/MySQLConfigurationTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/MySQLConfigurationTest.java
@@ -1,0 +1,34 @@
+package io.vertx.ext.asyncsql;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+/**
+ * Tests the configuration options of the MySQL client.
+ */
+public class MySQLConfigurationTest extends ConfigurationTest {
+
+  @Override
+  protected AsyncSQLClient createClient(Vertx vertx, JsonObject config) {
+    return MySQLClient.createNonShared(vertx, config);
+  }
+
+  @Override
+  public String sleepCommand(int seconds) {
+    return "sleep(" + seconds + ")";
+  }
+
+  @Override
+  protected String getEncodingStatement() {
+    return "SHOW VARIABLES LIKE 'character_set_connection'";
+  }
+
+  @Override
+  protected String getEncodingValueFromResults(List<JsonArray> results) {
+    return results.get(0).getString(1);
+  }
+
+}

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLConfigurationTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLConfigurationTest.java
@@ -1,0 +1,34 @@
+package io.vertx.ext.asyncsql;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+/**
+ * Tests the configuration options of the PostgreSQL client.
+ */
+public class PostgreSQLConfigurationTest extends ConfigurationTest {
+
+  @Override
+  protected AsyncSQLClient createClient(Vertx vertx, JsonObject config) {
+    return PostgreSQLClient.createNonShared(vertx, config);
+  }
+
+  @Override
+  public String sleepCommand(int seconds) {
+    return "pg_sleep(" + seconds + ")";
+  }
+
+  @Override
+  protected String getEncodingStatement() {
+    return "SHOW client_encoding";
+  }
+
+  @Override
+  protected String getEncodingValueFromResults(List<JsonArray> results) {
+    return results.get(0).getString(0);
+  }
+
+}

--- a/src/test/java/io/vertx/ext/asyncsql/SQLTestBase.java
+++ b/src/test/java/io/vertx/ext/asyncsql/SQLTestBase.java
@@ -19,7 +19,6 @@ package io.vertx.ext.asyncsql;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.sql.ResultSet;
@@ -27,38 +26,11 @@ import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.Test;
 
 import java.util.List;
 
-@RunWith(VertxUnitRunner.class)
-public abstract class SQLTestBase {
-
-  protected AsyncSQLClient client;
-  protected static Vertx vertx;
-  protected SQLConnection conn;
-
-  @BeforeClass
-  public static void setUp() {
-    vertx = Vertx.vertx();
-  }
-
-  @AfterClass
-  public static void tearDown(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
-  }
-
-  @After
-  public void cleanup(TestContext context) {
-    if (conn != null) {
-      conn.close(context.asyncAssertSuccess());
-    }
-    if (client != null) {
-      client.close(context.asyncAssertSuccess());
-    }
-  }
+public abstract class SQLTestBase extends AbstractTestBase {
 
   @Test
   public void testSimpleConnection(TestContext context) {
@@ -146,13 +118,6 @@ public abstract class SQLTestBase {
         });
       });
     });
-  }
-
-
-  protected void ensureSuccess(TestContext context, AsyncResult result) {
-    if (result.failed()) {
-      context.fail(result.cause());
-    }
   }
 
   @Test


### PR DESCRIPTION
This PR adds configuration options for charset and query timeout.

I have added the option for connection timeout, but it won't do anything yet, as the underlying driver doesn't seem to support it yet (see https://github.com/mauricio/postgresql-async/issues/6). There is an ignored / skipped test for it.