### PR TITLE
Fix date time and a bit refactoring

### DIFF
--- a/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
@@ -93,10 +93,10 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
     beginTransactionIfNeeded(v -> {
       final scala.concurrent.Future<QueryResult> future = connection.sendQuery(sql);
       future.onComplete(ScalaUtils.<QueryResult>toFunction1(ar -> {
-        if (ar.failed()) {
-          handler.handle(Future.failedFuture(ar.cause()));
-        } else {
+        if (ar.succeeded()) {
           handler.handle(Future.succeededFuture());
+        } else {
+          handler.handle(Future.failedFuture(ar.cause()));
         }
       }), executionContext);
     });
@@ -108,14 +108,7 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
   public SQLConnection query(String sql, Handler<AsyncResult<ResultSet>> handler) {
     beginTransactionIfNeeded(v -> {
       final Future<QueryResult> future = ScalaUtils.scalaToVertx(connection.sendQuery(sql), executionContext);
-      future.setHandler(ar -> {
-        if (ar.succeeded()) {
-          handler.handle(Future.succeededFuture(queryResultToResultSet(ar.result())));
-        } else {
-          handler.handle(Future.failedFuture(ar.cause()));
-        }
-
-      });
+      future.setHandler(handleAsyncQueryResultToResultSet(handler));
     });
 
     return this;
@@ -126,14 +119,7 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
     beginTransactionIfNeeded(v -> {
       final scala.concurrent.Future<QueryResult> future = connection.sendPreparedStatement(sql,
           ScalaUtils.toScalaList(params.getList()));
-      future.onComplete(ScalaUtils.<QueryResult>toFunction1(ar -> {
-        if (ar.succeeded()) {
-          handler.handle(Future.succeededFuture(queryResultToResultSet(ar.result())));
-        } else {
-          handler.handle(Future.failedFuture(ar.cause()));
-        }
-
-      }), executionContext);
+      future.onComplete(ScalaUtils.toFunction1(handleAsyncQueryResultToResultSet(handler)), executionContext);
     });
 
     return this;
@@ -144,10 +130,14 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
     beginTransactionIfNeeded(v -> {
       final scala.concurrent.Future<QueryResult> future = connection.sendQuery(sql);
       future.onComplete(ScalaUtils.<QueryResult>toFunction1(ar -> {
-        if (ar.failed()) {
-          handler.handle(Future.failedFuture(ar.cause()));
+        if (ar.succeeded()) {
+          try {
+            handler.handle(Future.succeededFuture(queryResultToUpdateResult(ar.result())));
+          } catch (Throwable e) {
+            handler.handle(Future.failedFuture(e));
+          }
         } else {
-          handler.handle(Future.succeededFuture(queryResultToUpdateResult(ar.result())));
+          handler.handle(Future.failedFuture(ar.cause()));
         }
       }), executionContext);
     });
@@ -161,10 +151,10 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
       final scala.concurrent.Future<QueryResult> future = connection.sendPreparedStatement(sql,
           ScalaUtils.toScalaList(params.getList()));
       future.onComplete(ScalaUtils.<QueryResult>toFunction1(ar -> {
-        if (ar.failed()) {
-          handler.handle(Future.failedFuture(ar.cause()));
-        } else {
+        try {
           handler.handle(Future.succeededFuture(queryResultToUpdateResult(ar.result())));
+        } catch (Throwable e) {
+          handler.handle(Future.failedFuture(e));
         }
       }), executionContext);
     });
@@ -242,6 +232,20 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
     }
   }
 
+  private Handler<AsyncResult<QueryResult>> handleAsyncQueryResultToResultSet(Handler<AsyncResult<ResultSet>> handler) {
+    return ar -> {
+      if (ar.succeeded()) {
+        try {
+          handler.handle(Future.succeededFuture(queryResultToResultSet(ar.result())));
+        } catch (Throwable e) {
+          handler.handle(Future.failedFuture(e));
+        }
+      } else {
+        handler.handle(Future.failedFuture(ar.cause()));
+      }
+    };
+  }
+
   private ResultSet queryResultToResultSet(QueryResult qr) {
     final Option<com.github.mauricio.async.db.ResultSet> rows = qr.rows();
     if (!rows.isDefined()) {
@@ -281,9 +285,9 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
           array.add(value.toString());
         } else if (value instanceof LocalDate) {
           array.add(value.toString());
-        } else if (value instanceof UUID) {
-          array.add(value.toString());
         } else if (value instanceof DateTime) {
+          array.add(value.toString());
+        } else if (value instanceof UUID) {
           array.add(value.toString());
         } else {
           array.add(value);

--- a/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
@@ -27,6 +27,7 @@ import io.vertx.ext.asyncsql.impl.pool.AsyncConnectionPool;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import scala.Option;
@@ -281,6 +282,8 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
         } else if (value instanceof LocalDate) {
           array.add(value.toString());
         } else if (value instanceof UUID) {
+          array.add(value.toString());
+        } else if (value instanceof DateTime) {
           array.add(value.toString());
         } else {
           array.add(value);

--- a/src/main/java/io/vertx/ext/asyncsql/impl/BaseSQLClient.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/BaseSQLClient.java
@@ -19,7 +19,6 @@ package io.vertx.ext.asyncsql.impl;
 import com.github.mauricio.async.db.Configuration;
 import com.github.mauricio.async.db.Connection;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.util.CharsetUtil;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;

--- a/src/test/java/io/vertx/ext/asyncsql/AbstractTestBase.java
+++ b/src/test/java/io/vertx/ext/asyncsql/AbstractTestBase.java
@@ -1,6 +1,7 @@
 package io.vertx.ext.asyncsql;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.unit.TestContext;
@@ -43,4 +44,13 @@ public abstract class AbstractTestBase {
     }
   }
 
+  protected <A> Handler<AsyncResult<A>> onSuccess(TestContext context, Handler<A> fn) {
+    return ar -> {
+      if (ar.succeeded()) {
+        fn.handle(ar.result());
+      } else {
+        context.fail("Should have been a success");
+      }
+    };
+  }
 }

--- a/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
@@ -20,7 +20,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
 import io.vertx.ext.unit.Async;

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLClientTest.java
@@ -16,14 +16,12 @@
 
 package io.vertx.ext.asyncsql;
 
-import com.github.mauricio.async.db.QueryResult;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.SQLConnection;
-import io.vertx.ext.sql.UpdateResult;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import org.junit.Before;

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
@@ -18,113 +18,88 @@ package io.vertx.ext.asyncsql;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.test.core.VertxTestBase;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
 
 /**
  * @author <a href="http://www.campudus.com">Joern Bernhardt</a>.
  */
-public class PostgreSQLTest extends VertxTestBase {
-
-  AsyncSQLClient asyncSqlClient;
-
-  final String address = "campudus.postgresql";
+public class PostgreSQLTest extends AbstractTestBase {
 
   final JsonObject config = new JsonObject()
-      .put("host", System.getProperty("db.host", "localhost"))
-      .put("postgresql", new JsonObject().put("address", address));
+      .put("host", System.getProperty("db.host", "localhost"));
 
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    asyncSqlClient = PostgreSQLClient.createNonShared(vertx, config);
+  @Before
+  public void init() {
+    client = PostgreSQLClient.createNonShared(vertx, config);
   }
 
-  @Override
-  public void tearDown() throws Exception {
-    CountDownLatch latch;
-    if (this.asyncSqlClient != null) {
-      latch = new CountDownLatch(1);
-      this.asyncSqlClient.close((ar) -> {
-        latch.countDown();
+  @Test
+  public void someTest(TestContext context) throws Exception {
+    Async async = context.async();
+    client.getConnection(connAr -> {
+      ensureSuccess(context, connAr);
+      conn = connAr.result();
+      conn.query("SELECT 1 AS something", resultSetAr -> {
+        ensureSuccess(context, resultSetAr);
+        ResultSet resultSet = resultSetAr.result();
+        context.assertNotNull(resultSet);
+        context.assertNotNull(resultSet.getColumnNames());
+        context.assertNotNull(resultSet.getResults());
+        context.assertEquals(new JsonArray().add(1), resultSet.getResults().get(0));
+        async.complete();
       });
-      this.awaitLatch(latch);
-    }
-
-    super.tearDown();
+    });
   }
 
   @Test
-  public void someTest() throws Exception {
-    asyncSqlClient.getConnection(onSuccess(conn -> {
-      conn.query("SELECT 1 AS something", onSuccess(resultSet -> {
-        System.out.println(resultSet.getResults());
-        assertNotNull(resultSet);
-        assertNotNull(resultSet.getColumnNames());
-        assertNotNull(resultSet.getResults());
-        assertEquals(new JsonArray().add(1), resultSet.getResults().get(0));
-        conn.close((ar) -> {
-          if (ar.succeeded()) {
-            testComplete();
-          } else {
-            fail("should be able to close the asyncSqlClient");
-          }
-        });
-      }));
-    }));
-
-    await();
-  }
-
-  @Test
-  public void queryTypeTimestampWithTimezoneTest() throws Exception {
-    asyncSqlClient.getConnection(onSuccess(conn -> {
-      conn.execute("CREATE TABLE IF NOT EXISTS timestamptest (ts timestamp with time zone)", onSuccess(resultSet -> {
-        conn.execute("INSERT INTO timestamptest (ts) VALUES (now())", onSuccess(rs1 -> {
-          conn.query("SELECT * FROM timestamptest;", onSuccess(rs2 -> {
-            assertNotNull(rs2);
-            assertNotNull(rs2.getResults());
-            conn.execute("DROP TABLE timestamptest", onSuccess(rs3 -> {
-              conn.close((ar) -> {
-                if (ar.succeeded()) {
-                  testComplete();
-                } else {
-                  fail("should be able to close the asyncSqlClient");
-                }
-              });
+  public void queryTypeTimestampWithTimezoneTest(TestContext context) throws Exception {
+    Async async = context.async();
+    client.getConnection(connAr -> {
+      ensureSuccess(context, connAr);
+      conn = connAr.result();
+      conn.execute("DROP TABLE IF EXISTS test_table", onSuccess(context, dropped -> {
+        conn.execute("CREATE TABLE IF NOT EXISTS test_table (ts timestamp with time zone)", onSuccess(context, created -> {
+          conn.execute("INSERT INTO test_table (ts) VALUES (now())", onSuccess(context, inserted -> {
+            conn.query("SELECT * FROM test_table;", onSuccess(context, timestampSelect -> {
+              context.assertNotNull(timestampSelect);
+              context.assertNotNull(timestampSelect.getResults());
+              context.assertTrue(timestampSelect.getResults().get(0).getString(0).matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}(Z|[+-]\\d{2}:\\d{2})"));
+              async.complete();
             }));
           }));
         }));
       }));
-    }));
-
-    await();
+    });
   }
 
   @Test
-  public void queryTypeTimestampWithoutTimezoneTest() throws Exception {
-    asyncSqlClient.getConnection(onSuccess(conn -> {
-      conn.execute("CREATE TABLE IF NOT EXISTS timestamptest (ts timestamp without time zone)", onSuccess(resultSet -> {
-        conn.execute("INSERT INTO timestamptest (ts) VALUES (now())", onSuccess(rs1 -> {
-          conn.query("SELECT * FROM timestamptest;", onSuccess(rs2 -> {
-            assertNotNull(rs2);
-            assertNotNull(rs2.getResults());
-            conn.execute("DROP TABLE timestamptest", onSuccess(rs3 -> {
-              conn.close((ar) -> {
-                if (ar.succeeded()) {
-                  testComplete();
-                } else {
-                  fail("should be able to close the asyncSqlClient");
-                }
-              });
+  public void queryTypeTimestampWithoutTimezoneTest(TestContext context) throws Exception {
+    Async async = context.async();
+    client.getConnection(connAr -> {
+      ensureSuccess(context, connAr);
+      conn = connAr.result();
+      conn.execute("DROP TABLE IF EXISTS test_table", onSuccess(context, dropped -> {
+        conn.execute("CREATE TABLE IF NOT EXISTS test_table (ts timestamp without time zone)", onSuccess(context, created -> {
+          conn.execute("INSERT INTO test_table (ts) VALUES (now())", onSuccess(context, inserted -> {
+            conn.query("SELECT * FROM test_table;", onSuccess(context, timestampSelect -> {
+              context.assertNotNull(timestampSelect);
+              context.assertNotNull(timestampSelect.getResults());
+              context.assertTrue(timestampSelect.getResults().get(0).getString(0).matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}"));
+              async.complete();
             }));
           }));
         }));
       }));
-    }));
-
-    await();
+    });
   }
+
 }

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
@@ -21,13 +21,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.test.core.VertxTestBase;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import java.util.concurrent.CountDownLatch;
 
 /**
  * @author <a href="http://www.campudus.com">Joern Bernhardt</a>.

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
@@ -78,4 +78,25 @@ public class PostgreSQLTest extends VertxTestBase {
     await();
   }
 
+  @Test
+  public void queryTypeTimestampWithTimezoneTest() throws Exception {
+    asyncSqlClient.getConnection(onSuccess(conn -> {
+      conn.execute("CREATE TABLE IF NOT EXISTS timestamptest (ts timestamp with time zone)", onSuccess(resultSet -> {
+        conn.execute("INSERT INTO timestamptest (ts) VALUES (now())", onSuccess(rs1 -> {
+          conn.query("SELECT * FROM timestamptest;", onSuccess(rs2 -> {
+
+            conn.close((ar) -> {
+              if (ar.succeeded()) {
+                testComplete();
+              } else {
+                fail("should be able to close the asyncSqlClient");
+              }
+            });
+          }));
+        }));
+      }));
+    }));
+
+    await();
+  }
 }

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
@@ -86,13 +86,15 @@ public class PostgreSQLTest extends VertxTestBase {
           conn.query("SELECT * FROM timestamptest;", onSuccess(rs2 -> {
             assertNotNull(rs2);
             assertNotNull(rs2.getResults());
-            conn.close((ar) -> {
-              if (ar.succeeded()) {
-                testComplete();
-              } else {
-                fail("should be able to close the asyncSqlClient");
-              }
-            });
+            conn.execute("DROP TABLE timestamptest", onSuccess(rs3 -> {
+              conn.close((ar) -> {
+                if (ar.succeeded()) {
+                  testComplete();
+                } else {
+                  fail("should be able to close the asyncSqlClient");
+                }
+              });
+            }));
           }));
         }));
       }));
@@ -109,13 +111,15 @@ public class PostgreSQLTest extends VertxTestBase {
           conn.query("SELECT * FROM timestamptest;", onSuccess(rs2 -> {
             assertNotNull(rs2);
             assertNotNull(rs2.getResults());
-            conn.close((ar) -> {
-              if (ar.succeeded()) {
-                testComplete();
-              } else {
-                fail("should be able to close the asyncSqlClient");
-              }
-            });
+            conn.execute("DROP TABLE timestamptest", onSuccess(rs3 -> {
+              conn.close((ar) -> {
+                if (ar.succeeded()) {
+                  testComplete();
+                } else {
+                  fail("should be able to close the asyncSqlClient");
+                }
+              });
+            }));
           }));
         }));
       }));

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
@@ -84,7 +84,31 @@ public class PostgreSQLTest extends VertxTestBase {
       conn.execute("CREATE TABLE IF NOT EXISTS timestamptest (ts timestamp with time zone)", onSuccess(resultSet -> {
         conn.execute("INSERT INTO timestamptest (ts) VALUES (now())", onSuccess(rs1 -> {
           conn.query("SELECT * FROM timestamptest;", onSuccess(rs2 -> {
+            assertNotNull(rs2);
+            assertNotNull(rs2.getResults());
+            conn.close((ar) -> {
+              if (ar.succeeded()) {
+                testComplete();
+              } else {
+                fail("should be able to close the asyncSqlClient");
+              }
+            });
+          }));
+        }));
+      }));
+    }));
 
+    await();
+  }
+
+  @Test
+  public void queryTypeTimestampWithoutTimezoneTest() throws Exception {
+    asyncSqlClient.getConnection(onSuccess(conn -> {
+      conn.execute("CREATE TABLE IF NOT EXISTS timestamptest (ts timestamp without time zone)", onSuccess(resultSet -> {
+        conn.execute("INSERT INTO timestamptest (ts) VALUES (now())", onSuccess(rs1 -> {
+          conn.query("SELECT * FROM timestamptest;", onSuccess(rs2 -> {
+            assertNotNull(rs2);
+            assertNotNull(rs2.getResults());
             conn.close((ar) -> {
               if (ar.succeeded()) {
                 testComplete();


### PR DESCRIPTION
Thanks for the patch @augeneinblick !

I've added a regexp to check that we look at a time with or without timezones and did some refactoring. Now almost all tests use vertx-unit instead of `VertxTestBase` - only `RefCountTest` is still using `VertxTestBase`.

There is also an additional `try/catch` block that handles unexpected types coming from the server.