### PR TITLE
Convert BigDecimal into strings to keep information

### DIFF
--- a/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
@@ -34,10 +34,7 @@ import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.runtime.AbstractFunction1;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Implementation of {@link SQLConnection} using the {@link AsyncConnectionPool}.
@@ -281,6 +278,8 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
       public Void apply(Object value) {
         if (value == null) {
           array.addNull();
+        } else if (value instanceof scala.math.BigDecimal) {
+          array.add(value.toString());
         } else if (value instanceof LocalDateTime) {
           array.add(value.toString());
         } else if (value instanceof LocalDate) {


### PR DESCRIPTION
This should fix issue #40 in part: Using `DECIMAL` in tables will decode to strings to not loose information in a `toDouble` conversion or similar.

@pmlopes can you please have a look? Maybe you have a better idea what we could do here. It's not possible to add `BigDecimal` to JSON or am I wrong in this assumption but didn't figure out how?