### PR TITLE
Allow raw types from the async-sql framework to propagate up.

### DIFF
--- a/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
@@ -27,14 +27,13 @@ import io.vertx.ext.asyncsql.impl.pool.AsyncConnectionPool;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.sql.UpdateResult;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalDateTime;
 import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.runtime.AbstractFunction1;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Implementation of {@link SQLConnection} using the {@link AsyncConnectionPool}.
@@ -272,28 +271,15 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
   }
 
   private JsonArray rowToJsonArray(RowData data) {
-    JsonArray array = new JsonArray();
+    List<Object> list = new ArrayList<>();
     data.foreach(new AbstractFunction1<Object, Void>() {
       @Override
       public Void apply(Object value) {
-        if (value == null) {
-          array.addNull();
-        } else if (value instanceof scala.math.BigDecimal) {
-          array.add(value.toString());
-        } else if (value instanceof LocalDateTime) {
-          array.add(value.toString());
-        } else if (value instanceof LocalDate) {
-          array.add(value.toString());
-        } else if (value instanceof DateTime) {
-          array.add(value.toString());
-        } else if (value instanceof UUID) {
-          array.add(value.toString());
-        } else {
-          array.add(value);
-        }
+        list.add(value);
         return null;
       }
     });
+    JsonArray array = new JsonArray(list);
     return array;
   }
 }


### PR DESCRIPTION
Converting the raw object types that come from the mauricio driver to strings to only have the application layer convert them back to their types is a terrible implementation. Not only do you get the performance hit, but it then forces the application layer to be littered with conversions. The only reason this is happening is because the JsonArray and JsonObject will check the values type and restrict it to an allowable subset. They do however not do the type checking when they are instantiated with a list or map.

There is a pull request for the async-sql-common framework as well.
