### PR TITLE
bug: JsonArray#getInstant() made by postgres client throws DateTimeParseException

### DIFF
--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLTest.java
@@ -21,6 +21,9 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+
+import java.time.Instant;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -128,4 +131,27 @@ public class PostgreSQLTest extends AbstractTestBase {
     });
   }
 
+  @Test
+  public void testInstant(TestContext context) {
+    Async async = context.async();
+    client.getConnection(ar -> {
+      ensureSuccess(context, ar);
+      conn = ar.result();
+      conn.execute("DROP TABLE IF EXISTS test_table", ar1 -> {
+        ensureSuccess(context, ar1);
+        conn.execute("CREATE TABLE test_table (instant TIMESTAMP)", ar2 -> {
+          ensureSuccess(context, ar2);
+          Instant now = Instant.now();
+          conn.queryWithParams("INSERT INTO test_table (instant) VALUES (?)", new JsonArray().add(now), ar3 -> {
+            ensureSuccess(context, ar3);
+            conn.query("SELECT instant FROM test_table", ar4 -> {
+              ensureSuccess(context, ar4);
+              context.assertEquals(ar4.result().getResults().get(0).getInstant(0), now);
+              async.complete();
+            });
+          });
+        });
+      });
+    });
+  }
 }


### PR DESCRIPTION
Currently I cannot use `JsonArray#getInstant(int)` to get record, because it throws exception like below. 

```
java.time.format.DateTimeParseException: Text '2016-07-24T14:32:24.363' could not be parsed at index 23
at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:1949)
at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1777)
at io.vertx.core.json.JsonArray.getInstant(JsonArray.java:233)
at io.vertx.ext.asyncsql.PostgreSQLTest.lambda$21(PostgreSQLTest.java:149)
at io.vertx.ext.asyncsql.impl.AsyncSQLConnectionImpl.lambda$handleAsyncQueryResultToResultSet$10(AsyncSQLConnectionImpl.java:260)
at io.vertx.core.impl.FutureImpl.checkCallHandler(FutureImpl.java:158)
at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:111)
at io.vertx.ext.asyncsql.impl.ScalaUtils$1.apply(ScalaUtils.java:41)
at io.vertx.ext.asyncsql.impl.ScalaUtils$1.apply(ScalaUtils.java:37)
at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
at io.vertx.ext.asyncsql.impl.VertxEventLoopExecutionContext.lambda$execute$1(VertxEventLoopExecutionContext.java:70)
at io.vertx.core.impl.ContextImpl.lambda$wrapTask$3(ContextImpl.java:359)
at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:339)
at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:393)
at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:742)
at java.lang.Thread.run(Thread.java:745)
```

It seems that the string data generated by this client lacks the last `'Z'`. I mean, text data should be `'2016-07-24T14:32:24.363Z'` but it is `'2016-07-24T14:32:24.363'` for now.

This PR contains a test which reproduces problem. I haven't found which code we should fix yet.
To test, I used postgres database which is installed by following docker command (same with the on in README).

```
docker run --rm --name vertx-postgres -e POSTGRES_USER=vertx -e POSTGRES_PASSWORD=password -e POSTGRES_DB=testdb -p 5432:5432 postgres
```