### PR TITLE
Streaming not supported yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ notifications:
   - vertx3-ci@googlegroups.com
 jdk:
 - oraclejdk8
+branches:
+  only:
+  - master
 before_install:
 - cp .travis.maven.settings.xml $HOME/.m2/settings.xml
 - sudo /etc/init.d/postgresql stop

--- a/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLConnectionImpl.java
@@ -26,6 +26,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.ext.asyncsql.impl.pool.AsyncConnectionPool;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.sql.SQLRowStream;
 import io.vertx.ext.sql.TransactionIsolation;
 import io.vertx.ext.sql.UpdateResult;
 import org.joda.time.DateTime;
@@ -115,6 +116,11 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
   }
 
   @Override
+  public SQLConnection queryStream(String s, Handler<AsyncResult<SQLRowStream>> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public SQLConnection queryWithParams(String sql, JsonArray params, Handler<AsyncResult<ResultSet>> handler) {
     beginTransactionIfNeeded(v -> {
       final scala.concurrent.Future<QueryResult> future = connection.sendPreparedStatement(sql,
@@ -123,6 +129,11 @@ public class AsyncSQLConnectionImpl implements SQLConnection {
     });
 
     return this;
+  }
+
+  @Override
+  public SQLConnection queryStreamWithParams(String s, JsonArray jsonArray, Handler<AsyncResult<SQLRowStream>> handler) {
+    throw new UnsupportedOperationException();
   }
 
   @Override


### PR DESCRIPTION
Add methods throwing UnsupportedOperationException.

This pull request is primarily for testing Travis setup, but we could also merge it to make the build pass again until we implement result streaming as in the jdbc client.