### PR TITLE
Added SSL support

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -228,7 +228,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "password" : <your-password>,
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
-  "queryTimeout" : <timeout-in-milliseconds>
+  "queryTimeout" : <timeout-in-milliseconds>,
+  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslrootcert" : <path to file with certificate>
 }
 ----
 
@@ -240,3 +242,12 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`sslmode` :: If you want to enable SSL support you should enable this parameter.
+             For example to connect Heroku you will need to use *prefer*.
+
+   "disable" ::: only try a non-SSL connection
+   "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
+   "require"  ::: only try an SSL connection, but don't verify Certificate Authority
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
+`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -229,8 +229,8 @@ Both the PostgreSql and MySql clients take the same configuration:
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
   "queryTimeout" : <timeout-in-milliseconds>,
-  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
-  "sslrootcert" : <path to file with certificate>
+  "sslMode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslRootCert" : <path to file with certificate>
 }
 ----
 
@@ -242,12 +242,15 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
-`sslmode` :: If you want to enable SSL support you should enable this parameter.
+`sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 
    "disable" ::: only try a non-SSL connection
    "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
    "require"  ::: only try an SSL connection, but don't verify Certificate Authority
-   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
-   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
-`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted
+                    certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and
+                      that the server host name matches that in the certificate
+`sslRootCert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+                 Refer to https://github.com/mauricio/postgresql-async[postgresql-async] documentation for more details.

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -196,7 +196,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "password" : <your-password>,
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
-  "queryTimeout" : <timeout-in-milliseconds>
+  "queryTimeout" : <timeout-in-milliseconds>,
+  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslrootcert" : <path to file with certificate>
 }
 ----
 
@@ -208,3 +210,12 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`sslmode` :: If you want to enable SSL support you should enable this parameter.
+             For example to connect Heroku you will need to use *prefer*.
+
+   "disable" ::: only try a non-SSL connection
+   "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
+   "require"  ::: only try an SSL connection, but don't verify Certificate Authority
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
+`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -197,8 +197,8 @@ Both the PostgreSql and MySql clients take the same configuration:
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
   "queryTimeout" : <timeout-in-milliseconds>,
-  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
-  "sslrootcert" : <path to file with certificate>
+  "sslMode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslRootCert" : <path to file with certificate>
 }
 ----
 
@@ -210,12 +210,15 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
-`sslmode` :: If you want to enable SSL support you should enable this parameter.
+`sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 
    "disable" ::: only try a non-SSL connection
    "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
    "require"  ::: only try an SSL connection, but don't verify Certificate Authority
-   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
-   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
-`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted
+                    certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and
+                      that the server host name matches that in the certificate
+`sslRootCert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+                 Refer to https://github.com/mauricio/postgresql-async[postgresql-async] documentation for more details.

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -235,8 +235,8 @@ Both the PostgreSql and MySql clients take the same configuration:
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
   "queryTimeout" : <timeout-in-milliseconds>,
-  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
-  "sslrootcert" : <path to file with certificate>
+  "sslMode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslRootCert" : <path to file with certificate>
 }
 ----
 
@@ -248,12 +248,15 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
-`sslmode` :: If you want to enable SSL support you should enable this parameter.
+`sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 
    "disable" ::: only try a non-SSL connection
    "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
    "require"  ::: only try an SSL connection, but don't verify Certificate Authority
-   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
-   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
-`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted
+                    certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and
+                      that the server host name matches that in the certificate
+`sslRootCert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+                 Refer to https://github.com/mauricio/postgresql-async[postgresql-async] documentation for more details.

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -234,7 +234,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "password" : <your-password>,
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
-  "queryTimeout" : <timeout-in-milliseconds>
+  "queryTimeout" : <timeout-in-milliseconds>,
+  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslrootcert" : <path to file with certificate>
 }
 ----
 
@@ -246,3 +248,12 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`sslmode` :: If you want to enable SSL support you should enable this parameter.
+             For example to connect Heroku you will need to use *prefer*.
+
+   "disable" ::: only try a non-SSL connection
+   "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
+   "require"  ::: only try an SSL connection, but don't verify Certificate Authority
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
+`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.

--- a/src/main/asciidoc/kotlin/index.adoc
+++ b/src/main/asciidoc/kotlin/index.adoc
@@ -228,7 +228,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "password" : <your-password>,
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
-  "queryTimeout" : <timeout-in-milliseconds>
+  "queryTimeout" : <timeout-in-milliseconds>,
+  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslrootcert" : <path to file with certificate>
 }
 ----
 
@@ -240,3 +242,12 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`sslmode` :: If you want to enable SSL support you should enable this parameter.
+             For example to connect Heroku you will need to use *prefer*.
+
+   "disable" ::: only try a non-SSL connection
+   "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
+   "require"  ::: only try an SSL connection, but don't verify Certificate Authority
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
+`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.

--- a/src/main/asciidoc/kotlin/index.adoc
+++ b/src/main/asciidoc/kotlin/index.adoc
@@ -229,8 +229,8 @@ Both the PostgreSql and MySql clients take the same configuration:
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
   "queryTimeout" : <timeout-in-milliseconds>,
-  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
-  "sslrootcert" : <path to file with certificate>
+  "sslMode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslRootCert" : <path to file with certificate>
 }
 ----
 
@@ -242,12 +242,15 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
-`sslmode` :: If you want to enable SSL support you should enable this parameter.
+`sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 
    "disable" ::: only try a non-SSL connection
    "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
    "require"  ::: only try an SSL connection, but don't verify Certificate Authority
-   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
-   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
-`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted
+                    certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and
+                      that the server host name matches that in the certificate
+`sslRootCert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+                 Refer to https://github.com/mauricio/postgresql-async[postgresql-async] documentation for more details.

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -235,8 +235,8 @@ Both the PostgreSql and MySql clients take the same configuration:
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
   "queryTimeout" : <timeout-in-milliseconds>,
-  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
-  "sslrootcert" : <path to file with certificate>
+  "sslMode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslRootCert" : <path to file with certificate>
 }
 ----
 
@@ -248,12 +248,15 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
-`sslmode` :: If you want to enable SSL support you should enable this parameter.
+`sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 
    "disable" ::: only try a non-SSL connection
    "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
    "require"  ::: only try an SSL connection, but don't verify Certificate Authority
-   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
-   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
-`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted
+                    certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and
+                      that the server host name matches that in the certificate
+`sslRootCert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+                 Refer to https://github.com/mauricio/postgresql-async[postgresql-async] documentation for more details.

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -234,7 +234,9 @@ Both the PostgreSql and MySql clients take the same configuration:
   "password" : <your-password>,
   "database" : <name-of-your-database>,
   "charset" : <name-of-the-character-set>,
-  "queryTimeout" : <timeout-in-milliseconds>
+  "queryTimeout" : <timeout-in-milliseconds>,
+  "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+  "sslrootcert" : <path to file with certificate>
 }
 ----
 
@@ -246,3 +248,12 @@ Both the PostgreSql and MySql clients take the same configuration:
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
 `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`sslmode` :: If you want to enable SSL support you should enable this parameter.
+             For example to connect Heroku you will need to use *prefer*.
+
+   "disable" ::: only try a non-SSL connection
+   "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
+   "require"  ::: only try an SSL connection, but don't verify Certificate Authority
+   "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
+   "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
+`sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.

--- a/src/main/java/io/vertx/ext/asyncsql/impl/BaseSQLClient.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/BaseSQLClient.java
@@ -30,7 +30,9 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.asyncsql.impl.pool.AsyncConnectionPool;
 import io.vertx.ext.sql.SQLConnection;
 import scala.Option;
+import scala.Tuple2;
 import scala.collection.Map$;
+import scala.collection.immutable.Map;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.Duration;
 
@@ -117,6 +119,8 @@ public abstract class BaseSQLClient {
     Option<Duration> queryTimeoutOption = (queryTimeout == null) ?
         Option.empty() : Option.apply(Duration.apply(queryTimeout, TimeUnit.MILLISECONDS));
 
+    Map<String, String> sslConfig = buildSslConfig(config);
+
     log.info("Creating configuration for " + host + ":" + port);
     return new Configuration(
         username,
@@ -124,7 +128,7 @@ public abstract class BaseSQLClient {
         port,
         Option.apply(password),
         Option.apply(database),
-        SSLConfiguration.apply(Map$.MODULE$.empty()),
+        SSLConfiguration.apply(sslConfig),
         charset,
         16777216,
         PooledByteBufAllocator.DEFAULT,
@@ -133,5 +137,15 @@ public abstract class BaseSQLClient {
         queryTimeoutOption);
   }
 
+  private Map<String, String> buildSslConfig(JsonObject config) {
+    Map<String, String> sslConfig = Map$.MODULE$.empty();
+    if (config.getString("sslmode")!= null) {
+      sslConfig = sslConfig.$plus(Tuple2.apply("sslmode", config.getString("sslmode")));
+    }
+    if (config.getString("sslrootcert") != null) {
+      sslConfig = sslConfig.$plus(Tuple2.apply("sslrootcert", config.getString("sslrootcert")));
+    }
+    return sslConfig;
+  }
 
 }

--- a/src/main/java/io/vertx/ext/asyncsql/impl/BaseSQLClient.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/BaseSQLClient.java
@@ -139,11 +139,11 @@ public abstract class BaseSQLClient {
 
   private Map<String, String> buildSslConfig(JsonObject config) {
     Map<String, String> sslConfig = Map$.MODULE$.empty();
-    if (config.getString("sslmode")!= null) {
-      sslConfig = sslConfig.$plus(Tuple2.apply("sslmode", config.getString("sslmode")));
+    if (config.getString("sslMode")!= null) {
+      sslConfig = sslConfig.$plus(Tuple2.apply("sslmode", config.getString("sslMode")));
     }
-    if (config.getString("sslrootcert") != null) {
-      sslConfig = sslConfig.$plus(Tuple2.apply("sslrootcert", config.getString("sslrootcert")));
+    if (config.getString("sslRootCert") != null) {
+      sslConfig = sslConfig.$plus(Tuple2.apply("sslrootcert", config.getString("sslRootCert")));
     }
     return sslConfig;
   }

--- a/src/main/java/io/vertx/ext/asyncsql/package-info.java
+++ b/src/main/java/io/vertx/ext/asyncsql/package-info.java
@@ -186,8 +186,8 @@
  *   "database" : <name-of-your-database>,
  *   "charset" : <name-of-the-character-set>,
  *   "queryTimeout" : <timeout-in-milliseconds>,
- *   "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
- *   "sslrootcert" : <path to file with certificate>
+ *   "sslMode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+ *   "sslRootCert" : <path to file with certificate>
  * }
  * ----
  *
@@ -199,15 +199,18 @@
  * `database`:: The name of the database you want to connect to. Defaults to `testdb`.
  * `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
  * `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
- * `sslmode` :: If you want to enable SSL support you should enable this parameter.
+ * `sslMode` :: If you want to enable SSL support you should enable this parameter.
  *              For example to connect Heroku you will need to use *prefer*.
  *
  *    "disable" ::: only try a non-SSL connection
  *    "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
  *    "require"  ::: only try an SSL connection, but don't verify Certificate Authority
- *    "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
- *    "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
- * `sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+ *    "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted
+ *                     certificate authority (CA)
+ *    "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and
+ *                       that the server host name matches that in the certificate
+ * `sslRootCert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
+ *                  Refer to https://github.com/mauricio/postgresql-async[postgresql-async] documentation for more details.
  */
 @Document(fileName = "index.adoc")
 @ModuleGen(name = "vertx-mysql-postgresql", groupPackage = "io.vertx") package io.vertx.ext.asyncsql;

--- a/src/main/java/io/vertx/ext/asyncsql/package-info.java
+++ b/src/main/java/io/vertx/ext/asyncsql/package-info.java
@@ -185,7 +185,9 @@
  *   "password" : <your-password>,
  *   "database" : <name-of-your-database>,
  *   "charset" : <name-of-the-character-set>,
- *   "queryTimeout" : <timeout-in-milliseconds>
+ *   "queryTimeout" : <timeout-in-milliseconds>,
+ *   "sslmode" : <"disable"|"prefer"|"require"|"verify-ca"|"verify-full">,
+ *   "sslrootcert" : <path to file with certificate>
  * }
  * ----
  *
@@ -197,6 +199,15 @@
  * `database`:: The name of the database you want to connect to. Defaults to `testdb`.
  * `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
  * `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+ * `sslmode` :: If you want to enable SSL support you should enable this parameter.
+ *              For example to connect Heroku you will need to use *prefer*.
+ *
+ *    "disable" ::: only try a non-SSL connection
+ *    "prefer"  ::: first try an SSL connection; if that fails, try a non-SSL connection
+ *    "require"  ::: only try an SSL connection, but don't verify Certificate Authority
+ *    "verify-ca"  ::: only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA)
+ *    "verify-full"  ::: only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate
+ * `sslrootcert` :: Path to SSL root certificate file. Is used if you want to verify privately issued certificate.
  */
 @Document(fileName = "index.adoc")
 @ModuleGen(name = "vertx-mysql-postgresql", groupPackage = "io.vertx") package io.vertx.ext.asyncsql;


### PR DESCRIPTION
Added SSL support, see #43
Now can be used with Heroku, as heroku supports only SSL.
