### PR TITLE
Move test for unavailable database up one level

### DIFF
--- a/src/test/java/io/vertx/ext/asyncsql/AbstractTestBase.java
+++ b/src/test/java/io/vertx/ext/asyncsql/AbstractTestBase.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 public abstract class AbstractTestBase {
 
   protected SQLClient client;
+  protected SQLClient clientNoDatabase;
   protected static Vertx vertx;
   protected SQLConnection conn;
 

--- a/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
@@ -144,4 +144,27 @@ public class MySQLClientTest extends SQLTestBase {
             ar2 -> conn.execute("CREATE TABLE test_table (id BIGINT AUTO_INCREMENT, name VARCHAR(255), PRIMARY KEY(id))",
                 ar3 -> conn.execute("COMMIT", handler::handle))));
   }
+
+  @Test
+  public void testUnavailableDatabase(TestContext testContext) {
+    AsyncSQLClient myClient = MySQLClient.createNonShared(vertx,
+      new JsonObject()
+        .put("host", "localhost")
+        .put("port", 65000)
+        .put("maxPoolSize", 2)
+    );
+    Async async = testContext.async(3);
+
+    Handler<AsyncResult<SQLConnection>> handler  = new Handler<AsyncResult<SQLConnection>>() {
+      @Override
+      public void handle(AsyncResult<SQLConnection> sqlConnectionAsyncResult) {
+        testContext.assertFalse(sqlConnectionAsyncResult.succeeded());
+        async.countDown();
+      }
+    };
+    myClient.getConnection(handler);
+    myClient.getConnection(handler);
+    myClient.getConnection(handler);
+  }
+
 }

--- a/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
@@ -37,6 +37,12 @@ public class MySQLClientTest extends SQLTestBase {
         new JsonObject()
             .put("host", System.getProperty("db.host", "localhost"))
     );
+    clientNoDatabase = MySQLClient.createNonShared(vertx,
+      new JsonObject()
+        .put("host", System.getProperty("db.host", "localhost"))
+        .put("port", 65000)
+        .put("maxPoolSize", 2)
+    );
   }
 
   // Configure the expected time used in the date test
@@ -144,27 +150,4 @@ public class MySQLClientTest extends SQLTestBase {
             ar2 -> conn.execute("CREATE TABLE test_table (id BIGINT AUTO_INCREMENT, name VARCHAR(255), PRIMARY KEY(id))",
                 ar3 -> conn.execute("COMMIT", handler::handle))));
   }
-
-  @Test
-  public void testUnavailableDatabase(TestContext testContext) {
-    AsyncSQLClient myClient = MySQLClient.createNonShared(vertx,
-      new JsonObject()
-        .put("host", "localhost")
-        .put("port", 65000)
-        .put("maxPoolSize", 2)
-    );
-    Async async = testContext.async(3);
-
-    Handler<AsyncResult<SQLConnection>> handler  = new Handler<AsyncResult<SQLConnection>>() {
-      @Override
-      public void handle(AsyncResult<SQLConnection> sqlConnectionAsyncResult) {
-        testContext.assertFalse(sqlConnectionAsyncResult.succeeded());
-        async.countDown();
-      }
-    };
-    myClient.getConnection(handler);
-    myClient.getConnection(handler);
-    myClient.getConnection(handler);
-  }
-
 }

--- a/src/test/java/io/vertx/ext/asyncsql/PostgreSQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/PostgreSQLClientTest.java
@@ -38,6 +38,12 @@ public class PostgreSQLClientTest extends SQLTestBase {
         new JsonObject()
             .put("host", System.getProperty("db.host", "localhost"))
     );
+    clientNoDatabase = PostgreSQLClient.createNonShared(vertx,
+      new JsonObject()
+        .put("host", System.getProperty("db.host", "localhost"))
+        .put("port", 65000)
+        .put("maxPoolSize", 2)
+    );
   }
 
   // Configure the expected time used in the date test

--- a/src/test/java/io/vertx/ext/asyncsql/SQLTestBase.java
+++ b/src/test/java/io/vertx/ext/asyncsql/SQLTestBase.java
@@ -710,7 +710,7 @@ public abstract class SQLTestBase extends AbstractTestBase {
 
             res
               .handler(row -> {
-                context.assertEquals(Data.NAMES.get(count.getAndIncrement()) ,row.getString(0));
+                context.assertEquals(Data.NAMES.get(count.getAndIncrement()), row.getString(0));
               })
               .endHandler(v -> {
                 context.assertEquals(Data.NAMES.size(), count.get());
@@ -745,4 +745,21 @@ public abstract class SQLTestBase extends AbstractTestBase {
       });
     });
   }
+
+  @Test
+  public void testUnavailableDatabase(TestContext testContext) {
+    Async async = testContext.async(3);
+
+    Handler<AsyncResult<SQLConnection>> handler = new Handler<AsyncResult<SQLConnection>>() {
+      @Override
+      public void handle(AsyncResult<SQLConnection> sqlConnectionAsyncResult) {
+        testContext.assertFalse(sqlConnectionAsyncResult.succeeded());
+        async.countDown();
+      }
+    };
+    clientNoDatabase.getConnection(handler);
+    clientNoDatabase.getConnection(handler);
+    clientNoDatabase.getConnection(handler);
+  }
+
 }


### PR DESCRIPTION
This is basically #87 but I've moved the test up a level and let it run against both MySQL and PostgreSQL. 