### PR TITLE
Add support for TIME columns

### DIFF
--- a/src/main/java/io/vertx/ext/asyncsql/impl/ScalaUtils.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/ScalaUtils.java
@@ -24,9 +24,11 @@ import io.vertx.core.json.JsonArray;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
+import org.joda.time.LocalTime;
 import scala.Function1;
 import scala.collection.immutable.List;
 import scala.concurrent.ExecutionContext;
+import scala.concurrent.duration.FiniteDuration;
 import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
@@ -117,6 +119,10 @@ public final class ScalaUtils {
       array.add(value.toString());
     } else if (value instanceof LocalDate) {
       array.add(value.toString());
+    } else if (value instanceof LocalTime) {
+      array.add(value.toString());
+    } else if (value instanceof FiniteDuration) {
+      array.add(((FiniteDuration) value).toMillis());
     } else if (value instanceof DateTime) {
       array.add(Instant.ofEpochMilli(((DateTime) value).getMillis()));
     } else if (value instanceof UUID) {
@@ -138,5 +144,5 @@ public final class ScalaUtils {
       array.add(value);
     }
   }
-  
+
 }

--- a/src/main/java/io/vertx/ext/asyncsql/impl/ScalaUtils.java
+++ b/src/main/java/io/vertx/ext/asyncsql/impl/ScalaUtils.java
@@ -122,7 +122,8 @@ public final class ScalaUtils {
     } else if (value instanceof LocalTime) {
       array.add(value.toString());
     } else if (value instanceof FiniteDuration) {
-      array.add(((FiniteDuration) value).toMillis());
+      String time = durationToString(((FiniteDuration) value).toMillis());
+      array.add(time);
     } else if (value instanceof DateTime) {
       array.add(Instant.ofEpochMilli(((DateTime) value).getMillis()));
     } else if (value instanceof UUID) {
@@ -145,4 +146,11 @@ public final class ScalaUtils {
     }
   }
 
+  private static String durationToString(long allInMillis) {
+    long hours = allInMillis / 1000 / 60 / 60;
+    long minutes = allInMillis / 1000 / 60 % 60;
+    long seconds = allInMillis / 1000 % 60;
+    long millis = allInMillis % 1000;
+    return String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, millis);
+  }
 }

--- a/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
@@ -115,6 +115,18 @@ public class MySQLClientTest extends SQLTestBase {
   }
 
   @Override
+  protected void compareTimeStrings(TestContext context, Object result, String expected) {
+    String[] values = expected.split("[:.]");
+    int hours = Integer.parseInt(values[0]);
+    int minutes = Integer.parseInt(values[1]);
+    int seconds = Integer.parseInt(values[2]);
+    int millis = Integer.parseInt(values[3]);
+
+    String resultStr = String.format("%d:%01d:%01d.%03d", hours, minutes, seconds, millis);
+    context.assertEquals(resultStr, expected);
+  }
+
+  @Override
   protected String createByteArray1TableColumn() {
     return "BIT(1)";
   }

--- a/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
+++ b/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
@@ -115,15 +115,9 @@ public class MySQLClientTest extends SQLTestBase {
   }
 
   @Override
-  protected void compareTimeStrings(TestContext context, Object result, String expected) {
-    String[] values = expected.split("[:.]");
-    int hours = Integer.parseInt(values[0]);
-    int minutes = Integer.parseInt(values[1]);
-    int seconds = Integer.parseInt(values[2]);
-    int millis = Integer.parseInt(values[3]);
-
-    String resultStr = String.format("%d:%01d:%01d.%03d", hours, minutes, seconds, millis);
-    context.assertEquals(resultStr, expected);
+  protected void compareTimeStrings(TestContext context, String result, String expected) {
+    // MySQL always only delivers seconds and truncates milliseconds to ".000"
+    context.assertEquals(result, expected.replaceAll("\\.\\d{3}$", ".000"));
   }
 
   @Override

--- a/src/test/java/io/vertx/ext/asyncsql/SQLTestBase.java
+++ b/src/test/java/io/vertx/ext/asyncsql/SQLTestBase.java
@@ -869,13 +869,20 @@ public abstract class SQLTestBase extends AbstractTestBase {
         ensureSuccess(context, ar1);
         conn.execute("CREATE TABLE test_table (timecolumn TIME)", ar2 -> {
           ensureSuccess(context, ar2);
-          String someTime = "11:12:13.456";
-          JsonArray args = new JsonArray().add(someTime);
-          conn.queryWithParams("INSERT INTO test_table (timecolumn) VALUES (?)", args, ar3 -> {
+          String someTime1 = "11:12:13.456";
+          String someTime2 = "01:02:00.120";
+          String someTime3 = "00:00:01.001";
+          JsonArray args = new JsonArray().add(someTime1).add(someTime2).add(someTime3);
+          conn.queryWithParams("INSERT INTO test_table (timecolumn) VALUES (?), (?), (?)", args, ar3 -> {
             ensureSuccess(context, ar3);
             conn.query("SELECT timecolumn FROM test_table", ar4 -> {
               ensureSuccess(context, ar4);
-              compareTimeStrings(context, ar4.result().getResults().get(0).getValue(0), someTime);
+              String result1 = ar4.result().getResults().get(0).getString(0);
+              String result2 = ar4.result().getResults().get(1).getString(0);
+              String result3 = ar4.result().getResults().get(2).getString(0);
+              compareTimeStrings(context, result1, someTime1);
+              compareTimeStrings(context, result2, someTime2);
+              compareTimeStrings(context, result3, someTime3);
               async.complete();
             });
           });
@@ -884,9 +891,8 @@ public abstract class SQLTestBase extends AbstractTestBase {
     });
   }
 
-  protected void compareTimeStrings(TestContext context, Object result, String expected) {
-    String resultStr = result.toString();
-    context.assertEquals(resultStr, expected);
+  protected void compareTimeStrings(TestContext context, String result, String expected) {
+    context.assertEquals(result, expected);
   }
 
   @Test


### PR DESCRIPTION
This addresses #92.

It will add support for TIME types. PostgreSQL returns a `LocalTime` and MySQL returns a `FiniteDuration`. I let `LocalTime` result in a string containing `HH:MM:SS.<millis>` and `FiniteDuration` results a long value of milliseconds.

WDYT @pmlopes ?