### PR TITLE
Updated documentation with values that can be passed in Configuration

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -237,11 +237,13 @@ Both the PostgreSql and MySql clients take the same configuration:
 `host`:: The host of the database. Defaults to `localhost`.
 `port`:: The port of the database. Defaults to `5432` for PostgreSQL and `3306` for MySQL.
 `maxPoolSize`:: The number of connections that may be kept open. Defaults to `10`.
-`username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
-`password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
+`username`:: The username to connect to the database. Defaults to `vertx`.
+`password`:: The password to connect to the database. Defaults to `password`.
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
-`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`connectTimeout`:: The timeout to wait for connecting to the database. Defaults to `10000` (= 10 seconds).
+`testTimeout`:: The timeout for connection tests performed by pools. Defaults to `10000` (= 10 seconds).
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Default is not set.
 `sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -205,11 +205,13 @@ Both the PostgreSql and MySql clients take the same configuration:
 `host`:: The host of the database. Defaults to `localhost`.
 `port`:: The port of the database. Defaults to `5432` for PostgreSQL and `3306` for MySQL.
 `maxPoolSize`:: The number of connections that may be kept open. Defaults to `10`.
-`username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
-`password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
+`username`:: The username to connect to the database. Defaults to `vertx`.
+`password`:: The password to connect to the database. Defaults to `password`.
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
-`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`connectTimeout`:: The timeout to wait for connecting to the database. Defaults to `10000` (= 10 seconds).
+`testTimeout`:: The timeout for connection tests performed by pools. Defaults to `10000` (= 10 seconds).
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Default is not set.
 `sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -243,11 +243,13 @@ Both the PostgreSql and MySql clients take the same configuration:
 `host`:: The host of the database. Defaults to `localhost`.
 `port`:: The port of the database. Defaults to `5432` for PostgreSQL and `3306` for MySQL.
 `maxPoolSize`:: The number of connections that may be kept open. Defaults to `10`.
-`username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
-`password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
+`username`:: The username to connect to the database. Defaults to `vertx`.
+`password`:: The password to connect to the database. Defaults to `password`.
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
-`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`connectTimeout`:: The timeout to wait for connecting to the database. Defaults to `10000` (= 10 seconds).
+`testTimeout`:: The timeout for connection tests performed by pools. Defaults to `10000` (= 10 seconds).
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Default is not set.
 `sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 

--- a/src/main/asciidoc/kotlin/index.adoc
+++ b/src/main/asciidoc/kotlin/index.adoc
@@ -237,11 +237,13 @@ Both the PostgreSql and MySql clients take the same configuration:
 `host`:: The host of the database. Defaults to `localhost`.
 `port`:: The port of the database. Defaults to `5432` for PostgreSQL and `3306` for MySQL.
 `maxPoolSize`:: The number of connections that may be kept open. Defaults to `10`.
-`username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
-`password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
+`username`:: The username to connect to the database. Defaults to `vertx`.
+`password`:: The password to connect to the database. Defaults to `password`.
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
-`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`connectTimeout`:: The timeout to wait for connecting to the database. Defaults to `10000` (= 10 seconds).
+`testTimeout`:: The timeout for connection tests performed by pools. Defaults to `10000` (= 10 seconds).
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Default is not set.
 `sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -243,11 +243,13 @@ Both the PostgreSql and MySql clients take the same configuration:
 `host`:: The host of the database. Defaults to `localhost`.
 `port`:: The port of the database. Defaults to `5432` for PostgreSQL and `3306` for MySQL.
 `maxPoolSize`:: The number of connections that may be kept open. Defaults to `10`.
-`username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
-`password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
+`username`:: The username to connect to the database. Defaults to `vertx`.
+`password`:: The password to connect to the database. Defaults to `password`.
 `database`:: The name of the database you want to connect to. Defaults to `testdb`.
 `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
-`queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+`connectTimeout`:: The timeout to wait for connecting to the database. Defaults to `10000` (= 10 seconds).
+`testTimeout`:: The timeout for connection tests performed by pools. Defaults to `10000` (= 10 seconds).
+`queryTimeout`:: The timeout to wait for a query in milliseconds. Default is not set.
 `sslMode` :: If you want to enable SSL support you should enable this parameter.
              For example to connect Heroku you will need to use *prefer*.
 

--- a/src/main/java/io/vertx/ext/asyncsql/package-info.java
+++ b/src/main/java/io/vertx/ext/asyncsql/package-info.java
@@ -194,11 +194,13 @@
  * `host`:: The host of the database. Defaults to `localhost`.
  * `port`:: The port of the database. Defaults to `5432` for PostgreSQL and `3306` for MySQL.
  * `maxPoolSize`:: The number of connections that may be kept open. Defaults to `10`.
- * `username`:: The username to connect to the database. Defaults to `postgres` for PostgreSQL and `root` for MySQL.
- * `password`:: The password to connect to the database. Default is not set, i.e. it uses no password.
+ * `username`:: The username to connect to the database. Defaults to `vertx`.
+ * `password`:: The password to connect to the database. Defaults to `password`.
  * `database`:: The name of the database you want to connect to. Defaults to `testdb`.
  * `charset`:: The name of the character set you want to use for the connection. Defaults to `UTF-8`.
- * `queryTimeout`:: The timeout to wait for a query in milliseconds. Defaults to `10000` (= 10 seconds).
+ * `connectTimeout`:: The timeout to wait for connecting to the database. Defaults to `10000` (= 10 seconds).
+ * `testTimeout`:: The timeout for connection tests performed by pools. Defaults to `10000` (= 10 seconds).
+ * `queryTimeout`:: The timeout to wait for a query in milliseconds. Default is not set.
  * `sslMode` :: If you want to enable SSL support you should enable this parameter.
  *              For example to connect Heroku you will need to use *prefer*.
  *


### PR DESCRIPTION
This Pull Request fixes #106 .

Documentation has been updated with some missing properties that can be passed in the configuration object, such as `connectTimeout` and `testTimeout`.

Some other values in the configuration, such as `username`, `password`, or `queryTimeout`, are described with wrong default values in the documentation.


Signed-off-by: Ernesto J. Perez <ernestojpg@gmail.com>
