### PR TITLE
exclude netty-all from mysql-async dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
`netty-all` already excluded from `postgresql-async` dependency, but not from `mysql-async`