### PR TITLE
Backported `Catch the exception thrown by the synchronization` to 3.6

### DIFF
--- a/vertx-mysql-postgresql-client-jasync/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLClientImpl.java
+++ b/vertx-mysql-postgresql-client-jasync/src/main/java/io/vertx/ext/asyncsql/impl/AsyncSQLClientImpl.java
@@ -17,12 +17,15 @@
 package io.vertx.ext.asyncsql.impl;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.asyncsql.AsyncSQLClient;
-import io.vertx.ext.sql.SQLClient;
-import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.sql.*;
+
+import java.util.function.Function;
 
 /**
  * @author <a href="http://www.campudus.com">Joern Bernhardt</a>.
@@ -55,4 +58,68 @@ public class AsyncSQLClientImpl implements AsyncSQLClient {
     return this;
   }
 
+  @Override
+  public SQLClient query(String sql, Handler<AsyncResult<ResultSet>> handler) {
+    executeDirect(conn -> Future.future(f -> conn.query(sql, f)), handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient queryStream(String sql, Handler<AsyncResult<SQLRowStream>> handler) {
+    executeDirect(conn -> Future.future(f -> conn.queryStream(sql, f)), handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient queryStreamWithParams(String sql, JsonArray params, Handler<AsyncResult<SQLRowStream>> handler) {
+    executeDirect(conn -> Future.future(f -> conn.queryStreamWithParams(sql, params, f)), handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient queryWithParams(String sql, JsonArray params, Handler<AsyncResult<ResultSet>> handler) {
+    executeDirect(conn -> Future.future(f -> conn.queryWithParams(sql, params, f)), handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient update(String sql, Handler<AsyncResult<UpdateResult>> handler) {
+    executeDirect(conn -> Future.future(f -> conn.update(sql, f)), handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient updateWithParams(String sql, JsonArray params, Handler<AsyncResult<UpdateResult>> handler) {
+    executeDirect(conn -> Future.future(f -> conn.updateWithParams(sql, params, f)), handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient call(String sql, Handler<AsyncResult<ResultSet>> handler) {
+    executeDirect(conn -> Future.future(f -> conn.call(sql, f)), handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient callWithParams(String sql, JsonArray params, JsonArray outputs, Handler<AsyncResult<ResultSet>> handler) {
+    executeDirect(conn -> Future.future(f -> conn.callWithParams(sql, params, outputs, f)), handler);
+    return this;
+  }
+
+  private <T> void executeDirect(Function<SQLConnection, Future<T>> action, Handler<AsyncResult<T>> handler) {
+    getConnection(getConnection -> {
+      if (getConnection.failed()) {
+        handler.handle(Future.failedFuture(getConnection.cause()));
+      } else {
+        final SQLConnection conn = getConnection.result();
+        Future<T> future;
+        try {
+          future = action.apply(conn);
+        } catch (Throwable e) {
+          future = Future.failedFuture(e);
+        }
+        future.setHandler(handler);
+      }
+    });
+  }
 }

--- a/vertx-mysql-postgresql-client-jasync/src/main/java/io/vertx/ext/asyncsql/impl/ClientWrapper.java
+++ b/vertx-mysql-postgresql-client-jasync/src/main/java/io/vertx/ext/asyncsql/impl/ClientWrapper.java
@@ -18,9 +18,9 @@ package io.vertx.ext.asyncsql.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
 import io.vertx.ext.asyncsql.AsyncSQLClient;
-import io.vertx.ext.sql.SQLClient;
-import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.sql.*;
 
 /**
  * Wraps a client with the {@link ClientHolder} in order to keep track of the references.
@@ -50,5 +50,53 @@ public class ClientWrapper implements AsyncSQLClient {
   @Override
   public SQLClient getConnection(Handler<AsyncResult<SQLConnection>> handler) {
     return client.getConnection(handler);
+  }
+
+  @Override
+  public SQLClient query(String sql, Handler<AsyncResult<ResultSet>> handler) {
+    client.query(sql, handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient queryStream(String sql, Handler<AsyncResult<SQLRowStream>> handler) {
+    client.queryStream(sql, handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient queryStreamWithParams(String sql, JsonArray params, Handler<AsyncResult<SQLRowStream>> handler) {
+    client.queryStreamWithParams(sql, params, handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient queryWithParams(String sql, JsonArray params, Handler<AsyncResult<ResultSet>> handler) {
+    client.queryWithParams(sql, params, handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient update(String sql, Handler<AsyncResult<UpdateResult>> handler) {
+    client.update(sql, handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient updateWithParams(String sql, JsonArray params, Handler<AsyncResult<UpdateResult>> handler) {
+    client.updateWithParams(sql, params, handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient call(String sql, Handler<AsyncResult<ResultSet>> handler) {
+    client.call(sql, handler);
+    return this;
+  }
+
+  @Override
+  public SQLClient callWithParams(String sql, JsonArray params, JsonArray outputs, Handler<AsyncResult<ResultSet>> handler) {
+    client.callWithParams(sql, params, outputs, handler);
+    return this;
   }
 }

--- a/vertx-mysql-postgresql-client-jasync/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
+++ b/vertx-mysql-postgresql-client-jasync/src/test/java/io/vertx/ext/asyncsql/MySQLClientTest.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.asyncsql;
 
+import com.github.jasync.sql.db.exceptions.InsufficientParametersException;
 import io.vertx.ext.asyncsql.category.NeedsDocker;
 import org.junit.*;
 
@@ -113,6 +114,18 @@ public class MySQLClientTest extends SQLTestBase {
           });
         });
       });
+    });
+  }
+
+  @Test
+  public void test(TestContext context){
+    JsonArray arr = new JsonArray().add(1).add(2);
+    Async async = context.async();
+    // a exception will throw. @see https://github.com/jasync-sql/jasync-sql/blob/master/mysql-async/src/main/java/com/github/jasync/sql/db/mysql/MySQLConnection.kt#L288-L301
+    client.queryWithParams("?", arr, r -> {
+      context.assertTrue(r.failed());
+      context.assertTrue(r.cause() instanceof InsufficientParametersException);
+      async.complete();
     });
   }
 


### PR DESCRIPTION
fixed #151