### PR TITLE
Remove expired connections from timers map.

### DIFF
--- a/vertx-mysql-postgresql-client-jasync/src/test/java/io/vertx/ext/asyncsql/impl/pool/AsyncConnectionPoolReleaseTest.java
+++ b/vertx-mysql-postgresql-client-jasync/src/test/java/io/vertx/ext/asyncsql/impl/pool/AsyncConnectionPoolReleaseTest.java
@@ -1,0 +1,129 @@
+package io.vertx.ext.asyncsql.impl.pool;
+
+import com.github.jasync.sql.db.Connection;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.asyncsql.impl.pool.AsyncConnectionPool;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+
+@RunWith(VertxUnitRunner.class)
+public class AsyncConnectionPoolReleaseTest {
+  private static final int MAX_POOL_SIZE = 3;
+  private static final JsonObject globalConfiguration = new JsonObject()
+      .put("maxPoolSize", MAX_POOL_SIZE)
+      .put("connectionReleaseDelay", 10);
+
+  private Vertx vertx;
+  /** Timers in first in first out order */
+  private Map<Long, Handler<Long>> timers = new LinkedHashMap<>();
+
+  @Before
+  public void setUp() {
+    this.vertx = Mockito.mock(Vertx.class);
+    Mockito.when(vertx.setTimer(Mockito.anyLong(), Mockito.any())).then(invocation -> {
+      long timerId = ThreadLocalRandom.current().nextLong();
+      Handler<Long> handler = invocation.getArgument(1);
+      timers.put(timerId, handler);
+      return timerId;
+    });
+    Mockito.when(vertx.cancelTimer(Mockito.anyLong())).then(invocation -> {
+      long timerId = invocation.getArgument(0);
+      Handler<Long> handler = timers.remove(timerId);
+      return handler != null;
+    });
+  }
+
+  @After
+  public void allTimersWereExcuted(TestContext context) {
+    context.assertEquals(0, timers.size());
+  }
+
+  private void executeNextTimer() {
+    Iterator<Entry<Long, Handler<Long>>> iterator = timers.entrySet().iterator();
+    Entry<Long, Handler<Long>> entry = iterator.next();
+    iterator.remove();
+    Long timerId = entry.getKey();
+    Handler<Long> handler = entry.getValue();
+    handler.handle(timerId);
+  }
+
+  @Test
+  public void releaseOneConnection(TestContext context) throws Exception {
+    final AsyncConnectionPool pool = Mockito.spy(new AsyncConnectionPoolMock());
+    pool.take(context.asyncAssertSuccess(connection -> {
+      context.assertEquals(0, pool.getTimersSize());
+      pool.giveBack(connection);
+      context.assertEquals(1, pool.getTimersSize());
+      executeNextTimer();
+      context.assertEquals(0, pool.getTimersSize());
+    }));
+  }
+
+  @Test
+  public void releaseThreeConnections(TestContext context) throws Exception {
+    final AsyncConnectionPool pool = Mockito.spy(new AsyncConnectionPoolMock());
+    pool.take(context.asyncAssertSuccess(connection1 -> {
+      pool.take(context.asyncAssertSuccess(connection2 -> {
+        pool.take(context.asyncAssertSuccess(connection3 -> {
+          context.assertEquals(0, pool.getTimersSize());
+          pool.giveBack(connection2);
+          pool.giveBack(connection3);
+          pool.giveBack(connection1);
+          context.assertEquals(3, pool.getTimersSize());
+          executeNextTimer();
+          executeNextTimer();
+          executeNextTimer();
+          context.assertEquals(0, pool.getTimersSize());
+        }));
+      }));
+    }));
+  }
+
+  @Test
+  public void cancelReleaseTimer(TestContext context) throws Exception {
+    final AsyncConnectionPool pool = Mockito.spy(new AsyncConnectionPoolMock());
+    pool.take(context.asyncAssertSuccess(connection -> {
+      context.assertEquals(0, pool.getTimersSize());
+      pool.giveBack(connection);
+      context.assertEquals(1, pool.getTimersSize());
+      pool.take(context.asyncAssertSuccess(connection2 -> {
+        context.assertEquals(connection, connection2);
+        context.assertEquals(0, pool.getTimersSize());
+        pool.giveBack(connection);
+        context.assertEquals(1, pool.getTimersSize());
+        executeNextTimer();
+        context.assertEquals(0, pool.getTimersSize());
+      }));
+    }));
+  }
+
+  private class AsyncConnectionPoolMock extends AsyncConnectionPool {
+    AsyncConnectionPoolMock() {
+      super(AsyncConnectionPoolReleaseTest.this.vertx, globalConfiguration, null);
+    }
+
+    @Override
+    protected Connection create() {
+      final Connection connection = Mockito.mock(Connection.class);
+      Mockito.when(connection.connect()).then(answer -> CompletableFuture.completedFuture(connection));
+      Mockito.when(connection.isConnected()).thenReturn(true);
+      return connection;
+    }
+  }
+}

--- a/vertx-mysql-postgresql-client-jasync/src/test/java/io/vertx/ext/asyncsql/impl/pool/AsyncConnectionPoolTest.java
+++ b/vertx-mysql-postgresql-client-jasync/src/test/java/io/vertx/ext/asyncsql/impl/pool/AsyncConnectionPoolTest.java
@@ -14,7 +14,7 @@
  *  You may elect to redistribute this code under either of these licenses.
  */
 
-package io.vertx.ext.asyncsql.impl.tool;
+package io.vertx.ext.asyncsql.impl.pool;
 
 import com.github.jasync.sql.db.Connection;
 
@@ -100,57 +100,6 @@ public class AsyncConnectionPoolTest {
       context.assertEquals(MAX_POOL_SIZE, connectionSet.size());
       context.assertEquals(TEST_LENGTH - i, (int)countDownLatch.getCount());
     }
-  }
-
-  @Test
-  public void testReleaseConnections(TestContext context) throws InterruptedException {
-    final int TEST_LENGTH = 26;
-    final long DELAY = 123L;
-
-    final AsyncConnectionPoolMock pool = Mockito.spy(new AsyncConnectionPoolMock(
-      new JsonObject()
-        .put("maxPoolSize", MAX_POOL_SIZE)
-        .put("connectionReleaseDelay", DELAY),
-      this::getGoodConnection));
-
-    final Async testLengthAsync = context.async(TEST_LENGTH);
-    final Async maxPoolSizeAsync = context.async(MAX_POOL_SIZE);
-    final Queue<Connection> connectionSet = new LinkedList<>();
-    for (int i = 0; i < TEST_LENGTH; i++) {
-      pool.take(result -> {
-        context.assertTrue(result.succeeded());
-        connectionSet.add(result.result());
-        testLengthAsync.countDown();
-        maxPoolSizeAsync.countDown();
-      });
-    }
-    maxPoolSizeAsync.await(1000);
-    context.assertEquals(MAX_POOL_SIZE, pool.connectionAttempts);
-    context.assertEquals(MAX_POOL_SIZE, pool.createdConnections);
-    context.assertEquals(MAX_POOL_SIZE, pool.getPoolSize());
-
-    for (int i = MAX_POOL_SIZE; i < TEST_LENGTH; i++) {
-      pool.giveBack(connectionSet.poll());
-    }
-    testLengthAsync.await(1000);
-    context.assertEquals(TEST_LENGTH, pool.connectionAttempts);
-    context.assertEquals(TEST_LENGTH, pool.createdConnections);
-    context.assertEquals(MAX_POOL_SIZE, pool.getPoolSize());
-    Mockito.verify(vertx, Mockito.times(TEST_LENGTH - MAX_POOL_SIZE)).setTimer(Mockito.eq(DELAY), Mockito.any());
-
-    for (int i = 0; i < 2; i++)  {
-      pool.giveBack(connectionSet.poll());
-    }
-    context.assertEquals(TEST_LENGTH, pool.connectionAttempts);
-    context.assertEquals(TEST_LENGTH, pool.createdConnections);
-    context.assertEquals(MAX_POOL_SIZE - 2, pool.getPoolSize());
-
-    for (int i = 2; i < MAX_POOL_SIZE; i++)  {
-      pool.giveBack(connectionSet.poll());
-    }
-    Mockito.verify(pool, Mockito.timeout(1000).times(TEST_LENGTH)).expire(Mockito.any());
-    Mockito.verify(vertx, Mockito.times(TEST_LENGTH)).setTimer(Mockito.eq(DELAY), Mockito.any());
-    context.assertEquals(0, pool.getPoolSize());
   }
 
   // Test that by default we don't do any retry


### PR DESCRIPTION
Idle connections are released (closed) if connectionReleaseDelay is configured (see #136).
It was forgotten to also remove the connection instance from the timers map resulting in
an unlimited growth of the map.

This PR
* adds the fix to remove the connection from the timers map on connection release
* fixes the test package name typo "tool" -> "pool"
* moves the connections release unit tests into a separate unit test class